### PR TITLE
Update php72u.spec

### DIFF
--- a/SPECS/php72u.spec
+++ b/SPECS/php72u.spec
@@ -481,6 +481,7 @@ Provides: php-pdo_mysql, php-pdo_mysql%{?_isa}
 Provides: %{name}-pdo_mysql, %{name}-pdo_mysql%{?_isa}
 Provides: php-mysqlnd = %{version}-%{release}
 Provides: php-mysqlnd%{?_isa} = %{version}-%{release}
+Provides: php-mysql = %{version}-%{release}
 Conflicts: php-mysql < %{version}-%{release}
 Conflicts: php-mysqlnd < %{version}-%{release}
 


### PR DESCRIPTION
Shouldn't this provide php-mysql as well? Ran into a package that requires php-mysql and it tried to pull in php56u packages.