### PR TITLE
Provide php-mysql

### DIFF
--- a/SPECS/php72u.spec
+++ b/SPECS/php72u.spec
@@ -481,6 +481,8 @@ Provides: php-pdo_mysql, php-pdo_mysql%{?_isa}
 Provides: %{name}-pdo_mysql, %{name}-pdo_mysql%{?_isa}
 Provides: php-mysqlnd = %{version}-%{release}
 Provides: php-mysqlnd%{?_isa} = %{version}-%{release}
+Provides: php-mysql = %{version}-%{release}
+Provides: php-mysql%{?_isa} = %{version}-%{release}
 Conflicts: php-mysql < %{version}-%{release}
 Conflicts: php-mysqlnd < %{version}-%{release}
 


### PR DESCRIPTION
Should this provide php-mysql as well? Ran into an rpm that required php-mysql and it tried to pull in all the php56u packages as a result.